### PR TITLE
[Bug] fix height of the tag component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "thxmx-ui",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "private": false,
     "repository": {
         "type": "git",

--- a/src/lib/Tag/Tag.styles.ts
+++ b/src/lib/Tag/Tag.styles.ts
@@ -22,6 +22,7 @@ export const TagContainer = styled.span<{ size: keyof IThxmxSize; color: 'primar
         color: colors[`${color}-darker`],
         margin: THXMX_TAG_MARGIN_SIZES[size],
         borderRadius: '3px',
+        height: 'fit-content',
         '& >:first-of-type': {
             marginRight: '3px',
         },


### PR DESCRIPTION
# ⭐ [Bug] fix height of the tag component

## 📝 Description
the correction of the auto height of the tag component has been made. 

Fixes #33 

## 📷 Attachments
*Before:*
![image](https://user-images.githubusercontent.com/105958505/195736557-bd5d0fee-ac01-43b9-905b-ce85da19d6a6.png)


*After:* 
![image](https://user-images.githubusercontent.com/105958505/195851003-01a6ae32-f927-42c4-8cfb-acf5d02afc3e.png)
